### PR TITLE
Fix codegangsta/cli compile error

### DIFF
--- a/gosync/build.go
+++ b/gosync/build.go
@@ -3,10 +3,11 @@ package main
 import (
 	"encoding/binary"
 	"fmt"
-	"github.com/Redundancy/go-sync/filechecksum"
-	"github.com/codegangsta/cli"
 	"os"
 	"path/filepath"
+
+	"github.com/Redundancy/go-sync/filechecksum"
+	"github.com/codegangsta/cli"
 )
 
 func init() {
@@ -18,7 +19,11 @@ func init() {
 			Usage:     "build a .gosync file for a file",
 			Action:    Build,
 			Flags: []cli.Flag{
-				cli.IntFlag{"blocksize", DEFAULT_BLOCK_SIZE, "The block size to use for the gosync file"},
+				cli.IntFlag{
+					Name:  "blocksize",
+					Value: DEFAULT_BLOCK_SIZE,
+					Usage: "The block size to use for the gosync file",
+				},
 			},
 		},
 	)

--- a/gosync/diff.go
+++ b/gosync/diff.go
@@ -4,15 +4,16 @@ import (
 	"bufio"
 	"encoding/binary"
 	"fmt"
+	"io"
+	"os"
+	"runtime"
+	"time"
+
 	"github.com/Redundancy/go-sync/chunks"
 	"github.com/Redundancy/go-sync/comparer"
 	"github.com/Redundancy/go-sync/filechecksum"
 	sync_index "github.com/Redundancy/go-sync/index"
 	"github.com/codegangsta/cli"
-	"io"
-	"os"
-	"runtime"
-	"time"
 )
 
 func init() {
@@ -25,7 +26,11 @@ func init() {
 			Description: `Compare a file with a reference index, and print statistics on the comparison and performance.`,
 			Action:      Diff,
 			Flags: []cli.Flag{
-				cli.IntFlag{"p", runtime.NumCPU(), "The number of streams to use concurrently"},
+				cli.IntFlag{
+					Name:  "p",
+					Value: runtime.NumCPU(),
+					Usage: "The number of streams to use concurrently",
+				},
 			},
 		},
 	)

--- a/gosync/main.go
+++ b/gosync/main.go
@@ -6,12 +6,13 @@ package main
 
 import (
 	"fmt"
-	"github.com/codegangsta/cli"
 	"log"
 	"net/http"
 	_ "net/http/pprof"
 	"os"
 	"runtime"
+
+	"github.com/codegangsta/cli"
 )
 
 const (
@@ -24,8 +25,15 @@ func main() {
 	app.Name = "gosync"
 	app.Usage = "Build indexes, patches, patch files"
 	app.Flags = []cli.Flag{
-		cli.BoolFlag{"profile", "enable HTTP profiling"},
-		cli.IntFlag{"profilePort", 6060, "The number of streams to use concurrently"},
+		cli.BoolFlag{
+			Name:  "profile",
+			Usage: "enable HTTP profiling",
+		},
+		cli.IntFlag{
+			Name:  "profilePort",
+			Value: 6060,
+			Usage: "The number of streams to use concurrently",
+		},
 	}
 
 	runtime.GOMAXPROCS(runtime.NumCPU())

--- a/gosync/patch.go
+++ b/gosync/patch.go
@@ -4,6 +4,11 @@ import (
 	"bufio"
 	"encoding/binary"
 	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"runtime"
+
 	"github.com/Redundancy/go-sync/blocksources"
 	"github.com/Redundancy/go-sync/chunks"
 	"github.com/Redundancy/go-sync/comparer"
@@ -11,10 +16,6 @@ import (
 	sync_index "github.com/Redundancy/go-sync/index"
 	"github.com/Redundancy/go-sync/patcher/sequential"
 	"github.com/codegangsta/cli"
-	"io"
-	"io/ioutil"
-	"os"
-	"runtime"
 )
 
 func init() {
@@ -32,7 +33,11 @@ The index should be produced by "gosync build".
 <output> is optional. If not specified, the local file will be overwritten when done.`,
 			Action: Patch,
 			Flags: []cli.Flag{
-				cli.IntFlag{"p", runtime.NumCPU(), "The number of streams to use concurrently"},
+				cli.IntFlag{
+					Name:  "p",
+					Value: runtime.NumCPU(),
+					Usage: "The number of streams to use concurrently",
+				},
 			},
 		},
 	)


### PR DESCRIPTION
codegangsta/cli has added a new value to the Flag struct (to read input
from an environment variable), so these files no longer compile without
error.  This change revises the code in a backwards-compatible way to
compile succesfully with master on codegangsta/cli.

cc @Redundancy 

P.S. - The imports moving are from my editor's `goimports`-on-save hook.  If you find them extremely annoying let me know and I will rebase to remove them from the PR, but I figured they would probably be fine.
