### PR TITLE
Convert to module and import gosync-cmd using cmd pattern

### DIFF
--- a/blocksources/fixed_size_block_resolver_test.go
+++ b/blocksources/fixed_size_block_resolver_test.go
@@ -122,6 +122,6 @@ func TestThatFileSizeTruncatesBlockEnds(t *testing.T) {
 	result := res.GetBlockEndOffset(3)
 
 	if result != 13 {
-		t.Errorf("Unexpected BlockEnd Offset:", result)
+		t.Errorf("Unexpected BlockEnd Offset: %v", result)
 	}
 }

--- a/cmd/gosync/build.go
+++ b/cmd/gosync/build.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/Redundancy/go-sync/filechecksum"
+	"github.com/urfave/cli/v2"
+)
+
+func init() {
+	app.Commands = append(
+		app.Commands,
+		&cli.Command{
+			Name:    "build",
+			Aliases: []string{"b"},
+			Usage:   "build a .gosync file for a file",
+			Action:  Build,
+			Flags: []cli.Flag{
+				&cli.IntFlag{
+					Name:  "blocksize",
+					Value: DefaultBlockSize,
+					Usage: "The block size to use for the gosync file",
+				},
+			},
+		},
+	)
+}
+
+func Build(c *cli.Context) error {
+	filename := c.Args().Get(0)
+	blocksize := uint32(c.Int("blocksize"))
+	generator := filechecksum.NewFileChecksumGenerator(uint(blocksize))
+	inputFile, err := os.Open(filename)
+
+	if err != nil {
+		absInputPath, err2 := filepath.Abs(filename)
+		if err2 == nil {
+			handleFileError(absInputPath, err)
+		} else {
+			handleFileError(filename, err)
+		}
+
+		os.Exit(1)
+	}
+
+	s, _ := inputFile.Stat()
+	// TODO: Error?
+	file_size := s.Size()
+
+	defer inputFile.Close()
+
+	ext := filepath.Ext(filename)
+	outfilePath := filename[:len(filename)-len(ext)] + ".gosync"
+	outputFile, err := os.Create(outfilePath)
+
+	if err != nil {
+		handleFileError(outfilePath, err)
+		os.Exit(1)
+	}
+
+	defer outputFile.Close()
+
+	if err = writeHeaders(
+		outputFile,
+		magicString,
+		blocksize,
+		file_size,
+		[]uint16{majorVersion, minorVersion, patchVersion},
+	); err != nil {
+		fmt.Fprintf(
+			os.Stderr,
+			"Error getting file info: %v %v\n",
+			filename,
+			err,
+		)
+		os.Exit(2)
+	}
+
+	start := time.Now()
+	_, err = generator.GenerateChecksums(inputFile, outputFile)
+	end := time.Now()
+
+	if err != nil {
+		fmt.Fprintf(
+			os.Stderr,
+			"Error generating checksum: %v %v\n",
+			filename,
+			err,
+		)
+		os.Exit(2)
+	}
+
+	inputFileInfo, err := os.Stat(filename)
+	if err != nil {
+		fmt.Fprintf(
+			os.Stderr,
+			"Error getting file info: %v %v\n",
+			filename,
+			err,
+		)
+		os.Exit(2)
+	}
+
+	fmt.Fprintf(
+		os.Stderr,
+		"Index for %v file generated in %v (%v bytes/S)\n",
+		inputFileInfo.Size(),
+		end.Sub(start),
+		float64(inputFileInfo.Size())/end.Sub(start).Seconds(),
+	)
+
+	return nil
+}

--- a/cmd/gosync/common.go
+++ b/cmd/gosync/common.go
@@ -1,0 +1,277 @@
+package main
+
+import (
+	"bufio"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+
+	"github.com/Redundancy/go-sync/chunks"
+	"github.com/Redundancy/go-sync/comparer"
+	"github.com/Redundancy/go-sync/filechecksum"
+	"github.com/Redundancy/go-sync/index"
+	"github.com/Redundancy/go-sync/patcher"
+	"github.com/urfave/cli/v2"
+)
+
+const (
+	// KB - One Kilobyte
+	KB = 1024
+	// MB - One Megabyte
+	MB = 1000000
+)
+
+func errorWrapper(c *cli.Context, f func(*cli.Context) error) {
+	defer func() {
+		if p := recover(); p != nil {
+			fmt.Fprintln(os.Stderr, p)
+			os.Exit(1)
+		}
+	}()
+
+	if err := f(c); err != nil {
+		fmt.Fprintln(os.Stderr, err.Error())
+		os.Exit(1)
+	}
+
+	return
+}
+
+func openFileAndHandleError(filename string) (f *os.File) {
+	var err error
+	f, err = os.Open(filename)
+
+	if err != nil {
+		f = nil
+		handleFileError(filename, err)
+	}
+
+	return
+}
+
+func formatFileError(filename string, err error) error {
+	switch {
+	case os.IsExist(err):
+		return fmt.Errorf(
+			"Could not open %v (already exists): %v",
+			filename,
+			err,
+		)
+	case os.IsNotExist(err):
+		return fmt.Errorf(
+			"Could not find %v: %v\n",
+			filename,
+			err,
+		)
+	case os.IsPermission(err):
+		return fmt.Errorf(
+			"Could not open %v (permission denied): %v\n",
+			filename,
+			err,
+		)
+	default:
+		return fmt.Errorf(
+			"Unknown error opening %v: %v\n",
+			filename,
+			err,
+		)
+	}
+}
+
+func handleFileError(filename string, err error) {
+	e := formatFileError(filename, err)
+	fmt.Fprintln(os.Stderr, e)
+}
+
+func getLocalOrRemoteFile(path string) (io.ReadCloser, error) {
+	url, err := url.Parse(path)
+
+	switch {
+	case err != nil:
+		return os.Open(path)
+	case url.Scheme == "":
+		return os.Open(path)
+	default:
+		response, err := http.Get(path)
+
+		if err != nil {
+			return nil, err
+		}
+
+		if response.StatusCode < 200 || response.StatusCode > 299 {
+			return nil, fmt.Errorf("Request to %v returned status: %v", path, response.Status)
+		}
+
+		return response.Body, nil
+	}
+}
+
+func toPatcherFoundSpan(sl comparer.BlockSpanList, blockSize int64) []patcher.FoundBlockSpan {
+	result := make([]patcher.FoundBlockSpan, len(sl))
+
+	for i, v := range sl {
+		result[i].StartBlock = v.StartBlock
+		result[i].EndBlock = v.EndBlock
+		result[i].MatchOffset = v.ComparisonStartOffset
+		result[i].BlockSize = blockSize
+	}
+
+	return result
+}
+
+func toPatcherMissingSpan(sl comparer.BlockSpanList, blockSize int64) []patcher.MissingBlockSpan {
+	result := make([]patcher.MissingBlockSpan, len(sl))
+
+	for i, v := range sl {
+		result[i].StartBlock = v.StartBlock
+		result[i].EndBlock = v.EndBlock
+		result[i].BlockSize = blockSize
+	}
+
+	return result
+}
+
+func writeHeaders(
+	f *os.File,
+	magic string,
+	blocksize uint32,
+	filesize int64,
+	versions []uint16,
+) (err error) {
+	if _, err = f.WriteString(magicString); err != nil {
+		return
+	}
+
+	for _, v := range versions {
+		if err = binary.Write(f, binary.LittleEndian, v); err != nil {
+			return
+		}
+	}
+
+	if err = binary.Write(f, binary.LittleEndian, filesize); err != nil {
+		return
+	}
+
+	err = binary.Write(f, binary.LittleEndian, blocksize)
+	return
+}
+
+// reads the file headers and checks the magic string, then the semantic versioning
+func readHeadersAndCheck(
+	r io.Reader,
+	magic string,
+	requiredMajorVersion uint16,
+) (
+	major, minor, patch uint16,
+	filesize int64,
+	blocksize uint32,
+	err error,
+) {
+	b := make([]byte, len(magicString))
+
+	if _, err = r.Read(b); err != nil {
+		return
+	} else if string(b) != magicString {
+		err = errors.New(
+			"file header does not match magic string. Not a valid gosync file",
+		)
+		return
+	}
+
+	for _, v := range []*uint16{&major, &minor, &patch} {
+		err = binary.Read(r, binary.LittleEndian, v)
+		if err != nil {
+			return
+		}
+	}
+
+	if requiredMajorVersion != major {
+		err = fmt.Errorf(
+			"The major version of the gosync file (%v.%v.%v) does not match the tool (%v.%v.%v).",
+			major, minor, patch,
+			majorVersion, minorVersion, patchVersion,
+		)
+
+		return
+	}
+
+	err = binary.Read(r, binary.LittleEndian, &filesize)
+	if err != nil {
+		return
+	}
+
+	err = binary.Read(r, binary.LittleEndian, &blocksize)
+	return
+}
+
+func readIndex(r io.Reader, blocksize uint) (
+	i *index.ChecksumIndex,
+	checksumLookup filechecksum.ChecksumLookup,
+	blockCount uint,
+	err error,
+) {
+	generator := filechecksum.NewFileChecksumGenerator(blocksize)
+
+	readChunks, e := chunks.LoadChecksumsFromReader(
+		r,
+		generator.WeakRollingHash.Size(),
+		generator.StrongHash.Size(),
+	)
+
+	err = e
+
+	if err != nil {
+		return
+	}
+
+	checksumLookup = chunks.StrongChecksumGetter(readChunks)
+	i = index.MakeChecksumIndex(readChunks)
+	blockCount = uint(len(readChunks))
+
+	return
+}
+
+func multithreadedMatching(
+	localFile *os.File,
+	idx *index.ChecksumIndex,
+	localFileSize,
+	matcherCount int64,
+	blocksize uint,
+) (*comparer.MatchMerger, *comparer.Comparer) {
+	// Note: Since not all sections of the file are equal in work
+	// it would be better to divide things up into more sections and
+	// pull work from a queue channel as each finish
+	sectionSize := localFileSize / matcherCount
+	sectionSize += int64(blocksize) - (sectionSize % int64(blocksize))
+	merger := &comparer.MatchMerger{}
+	compare := &comparer.Comparer{}
+
+	for i := int64(0); i < matcherCount; i++ {
+		offset := sectionSize * i
+
+		// Sections must overlap by blocksize (strictly blocksize - 1?)
+		if i > 0 {
+			offset -= int64(blocksize)
+		}
+
+		sectionReader := bufio.NewReaderSize(
+			io.NewSectionReader(localFile, offset, sectionSize),
+			MB,
+		)
+
+		sectionGenerator := filechecksum.NewFileChecksumGenerator(uint(blocksize))
+
+		matchStream := compare.StartFindMatchingBlocks(
+			sectionReader, offset, sectionGenerator, idx)
+
+		merger.StartMergeResultStream(matchStream, int64(blocksize))
+	}
+
+	return merger, compare
+}
+
+// better way to do this?

--- a/cmd/gosync/diff.go
+++ b/cmd/gosync/diff.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"time"
+
+	"github.com/urfave/cli/v2"
+)
+
+func init() {
+	app.Commands = append(
+		app.Commands,
+		&cli.Command{
+			Name:        "diff",
+			// ShortName:   "d",
+			Usage:       "gosync diff <localfile> <reference.gosync>",
+			Description: `Compare a file with a reference index, and print statistics on the comparison and performance.`,
+			Action:      Diff,
+			Flags: []cli.Flag{
+				&cli.IntFlag{
+					Name:  "p",
+					Value: runtime.NumCPU(),
+					Usage: "The number of streams to use concurrently",
+				},
+			},
+		},
+	)
+}
+
+func Diff(c *cli.Context) error {
+	localFilename := c.Args().First()
+	referenceFilename := c.Args().Get(1)
+	startTime := time.Now()
+
+	localFile := openFileAndHandleError(localFilename)
+
+	if localFile == nil {
+		os.Exit(1)
+	}
+
+	defer localFile.Close()
+
+	var blocksize uint32
+	referenceFile := openFileAndHandleError(referenceFilename)
+
+	if referenceFile == nil {
+		os.Exit(1)
+	}
+
+	defer referenceFile.Close()
+
+	_, _, _, _, blocksize, e := readHeadersAndCheck(
+		referenceFile,
+		magicString,
+		majorVersion,
+	)
+
+	if e != nil {
+		fmt.Printf("Error loading index: %v", e)
+		os.Exit(1)
+	}
+
+	fmt.Println("Blocksize: ", blocksize)
+
+	index, _, _, err := readIndex(referenceFile, uint(blocksize))
+	referenceFile.Close()
+
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("Weak hash count:", index.WeakCount())
+
+	fi, err := localFile.Stat()
+
+	if err != nil {
+		fmt.Println("Could not get info on file:", err)
+		os.Exit(1)
+	}
+
+	num_matchers := int64(c.Int("p"))
+
+	localFile_size := fi.Size()
+
+	// Don't split up small files
+	if localFile_size < 1024*1024 {
+		num_matchers = 1
+	}
+
+	merger, compare := multithreadedMatching(
+		localFile,
+		index,
+		localFile_size,
+		num_matchers,
+		uint(blocksize),
+	)
+
+	mergedBlocks := merger.GetMergedBlocks()
+
+	fmt.Println("\nMatched:")
+	totalMatchingSize := uint64(0)
+	matchedBlockCountAfterMerging := uint(0)
+
+	for _, b := range mergedBlocks {
+		totalMatchingSize += uint64(b.EndBlock-b.StartBlock+1) * uint64(blocksize)
+		matchedBlockCountAfterMerging += b.EndBlock - b.StartBlock + 1
+	}
+
+	fmt.Println("Comparisons:", compare.Comparisons)
+	fmt.Println("Weak hash hits:", compare.WeakHashHits)
+
+	if compare.Comparisons > 0 {
+		fmt.Printf(
+			"Weak hit rate: %.2f%%\n",
+			100.0*float64(compare.WeakHashHits)/float64(compare.Comparisons),
+		)
+	}
+
+	fmt.Println("Strong hash hits:", compare.StrongHashHits)
+	if compare.WeakHashHits > 0 {
+		fmt.Printf(
+			"Weak hash error rate: %.2f%%\n",
+			100.0*float64(compare.WeakHashHits-compare.StrongHashHits)/float64(compare.WeakHashHits),
+		)
+	}
+
+	fmt.Println("Total matched bytes:", totalMatchingSize)
+	fmt.Println("Total matched blocks:", matchedBlockCountAfterMerging)
+
+	// TODO: GetMissingBlocks uses the highest index, not the count, this can be pretty confusing
+	// Should clean up this interface to avoid that
+	missing := mergedBlocks.GetMissingBlocks(uint(index.BlockCount) - 1)
+	fmt.Println("Index blocks:", index.BlockCount)
+
+	totalMissingSize := uint64(0)
+	for _, b := range missing {
+		//fmt.Printf("%#v\n", b)
+		totalMissingSize += uint64(b.EndBlock-b.StartBlock+1) * uint64(blocksize)
+	}
+
+	fmt.Println("Approximate missing bytes:", totalMissingSize)
+	fmt.Println("Time taken:", time.Now().Sub(startTime))
+	return nil
+}

--- a/cmd/gosync/fileformat.md
+++ b/cmd/gosync/fileformat.md
@@ -1,0 +1,21 @@
+*NB: I'm documenting the current format of the gosync files merely as a point in time
+reference of format that is in use in the tool that is meant to serve as a practical reference and acceptance testing tool. The gosync tool is not intended as a production-worthy, well supported, tested tool.*
+
+*The format used exists entirely in service of being able to test the implementation of the gosync library as a cohesive whole in the real world, and therefore backwards and forwards compatibility (or even efficiency) are not primary concerns.*
+
+# Version 0.2.0
+###  The header
+(LE = little endian)
+* The string "G0S9NC" in UTF-8
+* versions*3 (eg. 0.1.2), uint16 LE 
+* filesize, int64 LE
+* blocksize uint32 LE
+
+### The body
+Repeating:
+* WeakChecksum
+* StrongChecksum
+
+each referring to blocks, starting at 0 (file start) and going upwards.
+
+In the current implementation of the FileChecksumGenerator used the WeakChecksum is the rolling checksum (4 bytes), and StrongChecksum is MD5 (16 bytes).

--- a/cmd/gosync/main.go
+++ b/cmd/gosync/main.go
@@ -1,0 +1,65 @@
+/*
+gosync is a command-line implementation of the gosync package functionality, primarily as a demonstration of usage
+but supposed to be functional in itself.
+*/
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	_ "net/http/pprof"
+	"os"
+	"runtime"
+
+	"github.com/urfave/cli/v2"
+)
+
+const (
+	DefaultBlockSize = 8192
+	magicString      = "G0S9NC" // just to confirm the file type is used correctly
+	majorVersion     = uint16(0)
+	minorVersion     = uint16(2)
+	patchVersion     = uint16(1)
+)
+
+var app = cli.NewApp()
+
+func main() {
+	app.Name = "gosync"
+	app.Usage = "Build indexes, patches, patch files"
+	app.Flags = []cli.Flag{
+		&cli.BoolFlag{
+			Name:  "profile",
+			Usage: "enable HTTP profiling",
+		},
+		&cli.IntFlag{
+			Name:  "profilePort",
+			Value: 6060,
+			Usage: "The number of streams to use concurrently",
+		},
+	}
+
+	app.Version = fmt.Sprintf(
+		"%v.%v.%v",
+		majorVersion,
+		minorVersion,
+		patchVersion,
+	)
+
+	runtime.GOMAXPROCS(runtime.NumCPU())
+
+	app.Before = func(c *cli.Context) error {
+		if c.Bool("profile") {
+			port := fmt.Sprint(c.Int("profilePort"))
+
+			go func() {
+				log.Println(http.ListenAndServe("localhost:"+port, nil))
+			}()
+		}
+
+		return nil
+	}
+
+	app.Run(os.Args)
+}

--- a/cmd/gosync/patch.go
+++ b/cmd/gosync/patch.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+
+	gosync_main "github.com/Redundancy/go-sync"
+	"github.com/urfave/cli/v2"
+)
+
+const usage = "gosync patch <localfile> <reference index> <reference source> [<output>]"
+
+func init() {
+	app.Commands = append(
+		app.Commands,
+		&cli.Command{
+			Name:      "patch",
+			Aliases: []string{"p"},
+			Usage:     usage,
+			Description: `Recreate the reference source file, using an index and a local file that is believed to be similar.
+The index should be produced by "gosync build".
+
+<reference index> is a .gosync file and may be a local, unc network path or http/https url
+<reference source> is corresponding target and may be a local, unc network path or http/https url
+<output> is optional. If not specified, the local file will be overwritten when done.`,
+			Action: Patch,
+			Flags: []cli.Flag{
+				&cli.IntFlag{
+					Name:  "p",
+					Value: runtime.NumCPU(),
+					Usage: "The number of streams to use concurrently",
+				},
+			},
+		},
+	)
+}
+
+// Patch a file
+func Patch(c *cli.Context) error {
+	errorWrapper(c, func(c *cli.Context) error {
+
+		fmt.Fprintln(os.Stderr, "Starting patching process")
+
+		if l := c.Args().Len(); l < 3 || l > 4 {
+			return fmt.Errorf(
+				"Usage is \"%v\" (invalid number of arguments)",
+				usage,
+			)
+		}
+
+		localFilename := c.Args().Get(0)
+		summaryFile := c.Args().Get(1)
+		referencePath := c.Args().Get(2)
+
+		outFilename := localFilename
+		if c.Args().Len() == 4 {
+			outFilename = c.Args().Get(3)
+		}
+
+		indexReader, e := os.Open(summaryFile)
+		if e != nil {
+			return e
+		}
+		defer indexReader.Close()
+
+		_, _, _, filesize, blocksize, e := readHeadersAndCheck(
+			indexReader,
+			magicString,
+			majorVersion,
+		)
+
+		index, checksumLookup, blockCount, err := readIndex(
+			indexReader,
+			uint(blocksize),
+		)
+
+		fs := &gosync_main.BasicSummary{
+			ChecksumIndex:  index,
+			ChecksumLookup: checksumLookup,
+			BlockCount:     blockCount,
+			BlockSize:      uint(blocksize),
+			FileSize:       filesize,
+		}
+
+		rsync, err := gosync_main.MakeRSync(
+			localFilename,
+			referencePath,
+			outFilename,
+			fs,
+		)
+
+		if err != nil {
+			return err
+		}
+
+		err = rsync.Patch()
+
+		if err != nil {
+			return err
+		}
+
+		return rsync.Close()
+	})
+	return nil
+}

--- a/comparer/merger.go
+++ b/comparer/merger.go
@@ -250,14 +250,14 @@ func (l BlockSpanList) Less(i, j int) bool {
 // Sorted list of blocks, based on StartBlock
 func (merger *MatchMerger) GetMergedBlocks() (sorted BlockSpanList) {
 	merger.wait.Wait()
-	var smallestKey uint = 0
+	// var smallestKey uint = 0
 	m := merger.startEndBlockMap
 
 	m.AscendGreaterOrEqual(m.Min(), func(item llrb.Item) bool {
 		switch block := item.(type) {
 		case BlockSpanStart:
 			sorted = append(sorted, BlockSpan(block))
-			smallestKey = block.StartBlock + 1
+			// smallestKey = block.StartBlock + 1
 		}
 		return true
 	})

--- a/comparer/merger_test.go
+++ b/comparer/merger_test.go
@@ -395,7 +395,7 @@ func TestRegression1Merger(t *testing.T) {
 		s := ORIGINAL_STRING[start:end]
 
 		if s != expected[i] {
-			t.Errorf("Wrong block %v: %v (expected %v)", i, expected[i])
+			t.Errorf("Wrong block: %v (expected %v)", i, expected[i])
 		}
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/Redundancy/go-sync
+
+go 1.14
+
+require (
+	github.com/petar/GoLLRB v0.0.0-20190514000832-33fb24c13b99
+	github.com/urfave/cli/v2 v2.2.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,15 @@
+github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=
+github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/petar/GoLLRB v0.0.0-20190514000832-33fb24c13b99 h1:KcEvVBAvyHkUdFAygKAzwB6LAcZ6LS32WHmRD2VyXMI=
+github.com/petar/GoLLRB v0.0.0-20190514000832-33fb24c13b99/go.mod h1:HUpKUBZnpzkdx0kD/+Yfuft+uD3zHGtXF/XJB14TUr4=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
+github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
+github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
+github.com/urfave/cli/v2 v2.2.0 h1:JTTnM6wKzdA0Jqodd966MVj4vWbbquZykeX1sKbe2C4=
+github.com/urfave/cli/v2 v2.2.0/go.mod h1:SE9GqnLQmjVa0iPEY0f1w3ygNIYcIJ0OKPMoW2caLfQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
This repo seems a little dated. I decided I'd update it a little to using Go modules. I also figured I'd update it to use the cmd directory pattern for nesting the CLI in the same repo. Makes for easier updates overall. 